### PR TITLE
Run unit tests only when version identifier is given

### DIFF
--- a/src/containers/cyclicbuffer.d
+++ b/src/containers/cyclicbuffer.d
@@ -13,7 +13,7 @@ private import std.range.primitives : empty, front, back, popFront, popBack;
 private import containers.internal.node : shouldAddGCRange;
 
 /**
- * Array that provides constant time (amortized) appending and popping
+ * An array that provides constant time (amortized) appending and popping
  * at either end, as well as random access to the elements.
  *
  * Params:
@@ -210,7 +210,7 @@ struct CyclicBuffer(T, Allocator = Mallocator, bool supportGC = shouldAddGCRange
 			.destroy(storage[pos]);
 	}
 
-	/// Accesses to the item at the start of the buffer.
+	/// Accesses the item at the start of the buffer.
 	auto ref front(this This)() nothrow pure @property @safe
 	{
 		version (assert) if (empty) onRangeError();
@@ -218,7 +218,7 @@ struct CyclicBuffer(T, Allocator = Mallocator, bool supportGC = shouldAddGCRange
 		return cast(ET) storage[start];
 	}
 
-	/// Accesses to the item at the end of the buffer.
+	/// Accesses the item at the end of the buffer.
 	auto ref back(this This)() nothrow pure @property @safe
 	{
 		version (assert) if (empty) onRangeError();
@@ -433,6 +433,8 @@ private:
 	ContainerStorageType!T[] storage;
 	size_t start, end, _length;
 }
+
+version (EmsiContainersUnittest):
 
 version (unittest) private
 {

--- a/src/containers/dynamicarray.d
+++ b/src/containers/dynamicarray.d
@@ -256,6 +256,8 @@ private:
 	size_t l;
 }
 
+version (EmsiContainersUnittest):
+
 unittest
 {
 	import std.algorithm : equal;
@@ -288,7 +290,7 @@ unittest
 
 version(unittest)
 {
-	class Cls
+	private class Cls
 	{
 		int* a;
 

--- a/src/containers/hashmap.d
+++ b/src/containers/hashmap.d
@@ -475,6 +475,8 @@ private:
 	size_t _length;
 }
 
+version (EmsiContainersUnittest):
+
 ///
 unittest
 {

--- a/src/containers/hashset.d
+++ b/src/containers/hashset.d
@@ -580,6 +580,8 @@ private:
 	size_t _length;
 }
 
+version (EmsiContainersUnittest):
+
 ///
 unittest
 {

--- a/src/containers/immutablehashset.d
+++ b/src/containers/immutablehashset.d
@@ -169,6 +169,8 @@ private:
 	Node[] nodes;
 }
 
+version (EmsiContainersUnittest):
+
 ///
 unittest
 {

--- a/src/containers/internal/element_type.d
+++ b/src/containers/internal/element_type.d
@@ -62,6 +62,8 @@ template ContainerElementType(ContainerType, ElementType)
 	}
 }
 
+version (EmsiContainersUnittest):
+
 unittest
 {
 	static struct Container {}

--- a/src/containers/internal/storage_type.d
+++ b/src/containers/internal/storage_type.d
@@ -70,6 +70,8 @@ template ContainerStorageType(T)
 		alias ContainerStorageType = T;
 }
 
+version (EmsiContainersUnittest):
+
 ///
 unittest
 {

--- a/src/containers/openhashset.d
+++ b/src/containers/openhashset.d
@@ -308,6 +308,8 @@ private:
 	}
 }
 
+version (EmsiContainersUnittest):
+
 unittest
 {
 	import std.string : format;

--- a/src/containers/simdset.d
+++ b/src/containers/simdset.d
@@ -217,6 +217,8 @@ private:
 	size_t _length;
 }
 
+version (EmsiContainersUnittest):
+
 ///
 version (D_InlineAsm_X86_64) unittest
 {

--- a/src/containers/slist.d
+++ b/src/containers/slist.d
@@ -266,6 +266,8 @@ private:
 	size_t _length;
 }
 
+version (EmsiContainersUnittest):
+
 unittest
 {
 	import std.string : format;

--- a/src/containers/treemap.d
+++ b/src/containers/treemap.d
@@ -142,6 +142,8 @@ private:
 		TreeType tree;
 }
 
+version (EmsiContainersUnittest):
+
 unittest
 {
 	TreeMap!(string, string) tm;

--- a/src/containers/ttree.d
+++ b/src/containers/ttree.d
@@ -884,6 +884,8 @@ private:
 	Node* root = null;
 }
 
+version (EmsiContainersUnittest):
+
 unittest
 {
 	import core.memory : GC;

--- a/src/containers/unrolledlist.d
+++ b/src/containers/unrolledlist.d
@@ -541,6 +541,8 @@ private:
 	}
 }
 
+version (EmsiContainersUnittest):
+
 unittest
 {
 	import std.algorithm : equal;

--- a/test/makefile
+++ b/test/makefile
@@ -2,7 +2,7 @@
 
 DC?=dmd
 SRC:=$(shell find ../src/ -name "*.d") $(shell find ../experimental_allocator -name "*.d")
-FLAGS:=-unittest -main -g -cov -I../src/ -debug -wi
+FLAGS:=-unittest -version=EmsiContainersUnittest -main -g -cov -I../src/ -debug -wi
 FLAGS32:=$(FLAGS) -m32
 
 all: test test_32 compile_test compile_test_32 external_allocator_test external_allocator_test_32
@@ -30,17 +30,18 @@ external_allocator_test_32: external_allocator_test.d $(SRC)
 
 looptest: looptest.d
 	$(DC) looptest.d -inline -O -release \
-		../src/memory/allocators.d \
 		../src/containers/ttree.d \
 		../src/containers/internal/node.d \
 		-I../src/ \
 
 clean:
-	rm -f tests
+	rm -f tests tests_32
+	rm -f compile_test compile_test_32
+	rm -f external_allocator_test external_allocator_test_32
 	rm -f *.o
 	rm -f *.dot
 	rm -f *.png
-	rm -f ..*.lst
+	rm -f *.lst .*.lst
 	rm -f looptest
 
 graphs: clean


### PR DESCRIPTION
Unit tests for `TTree` and friends require several seconds to complete. This may be inconvinient for end-users, when they repeatedly recompile a project, wishing to run *their own* tests.