### PR TITLE
Add Meson build definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
-sudo: false
-
 language: d
+sudo: false
+dist: trusty
 
 addons:
-    apt:
-        packages:
-            gcc-multilib
+  apt:
+    packages:
+      - pkg-config
+      - gcc-multilib
+
+install:
+  - pyenv global system 3.6
+  - pip3 install 'meson>=0.45'
+  - mkdir .ntmp
+  - curl -L https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip -o .ntmp/ninja-linux.zip
+  - unzip .ntmp/ninja-linux.zip -d .ntmp
+
+before_script:
+  export PATH=$PATH:$PWD/.ntmp
 
 script:
-- git submodule update --init --recursive
-- make -B -C test/
+  - meson build && ninja -j8 -C build
+  - ninja -j8 -C build test -v
+  - git submodule update --init --recursive
+  - make -B -C test/

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,88 @@
+project('dcontainers', 'd',
+    meson_version: '>=0.44',
+    license: 'BSL-1.0',
+    version: '0.8.0'
+)
+
+project_soversion = '0'
+
+pkgc = import('pkgconfig')
+allocator_dep = dependency('stdx-allocator', version: '>= 2.77', fallback: ['stdx-allocator', 'allocator_dep'])
+
+#
+# Sources
+#
+dcontainers_src = [
+    'src/containers/cyclicbuffer.d',
+    'src/containers/dynamicarray.d',
+    'src/containers/hashmap.d',
+    'src/containers/hashset.d',
+    'src/containers/immutablehashset.d',
+    'src/containers/internal/backwards.d',
+    'src/containers/internal/element_type.d',
+    'src/containers/internal/hash.d',
+    'src/containers/internal/mixins.d',
+    'src/containers/internal/node.d',
+    'src/containers/internal/storage_type.d',
+    'src/containers/openhashset.d',
+    'src/containers/package.d',
+    'src/containers/simdset.d',
+    'src/containers/slist.d',
+    'src/containers/treemap.d',
+    'src/containers/ttree.d',
+    'src/containers/unrolledlist.d'
+]
+
+src_dir = include_directories('src/')
+
+#
+# Targets
+#
+dcontainers_lib = library('dcontainers',
+        [dcontainers_src],
+        include_directories: [src_dir],
+        install: true,
+        version: meson.project_version(),
+        soversion: project_soversion,
+        dependencies: [allocator_dep]
+)
+
+pkgc.generate(name: 'dcontainers',
+              libraries: [dcontainers_lib],
+              subdirs: 'd/containers',
+              requires: ['stdx-allocator'],
+              version: meson.project_version(),
+              description: 'Containers backed by std.experimental.allocator.'
+)
+
+# for use by others which embed this as subproject
+dcontainers_dep = declare_dependency(
+    link_with: [dcontainers_lib],
+    include_directories: [src_dir],
+    dependencies: [allocator_dep]
+)
+
+#
+# Tests
+#
+dcontainers_test_exe = executable('test_dcontainers',
+    [dcontainers_src,
+    'test/compile_test.d',
+    'test/external_allocator_test.d'],
+    include_directories: [src_dir],
+    dependencies: [allocator_dep],
+    d_unittest: true,
+    link_args: '-main'
+)
+test('test_dcontainers', dcontainers_test_exe)
+
+# the looptest is a manual test, so we don't run it and only compile it
+looptest_test_exe = executable('test_looptest',
+    ['test/looptest.d'],
+    dependencies: [dcontainers_dep]
+)
+
+#
+# Install
+#
+install_subdir('src/containers/', install_dir: 'include/d/containers/')

--- a/subprojects/stdx-allocator.wrap
+++ b/subprojects/stdx-allocator.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory = stdx-allocator
+url       = https://github.com/dlang-community/stdx-allocator.git
+revision  = head


### PR DESCRIPTION
Another one ;-)
I really fear that if this continues, I will have written Meson files for half of the D ecosystem and packaged it as well (and it all started with just a tiny toy project...).

Meson calls this project "dcontainers", so I don't run into big trouble later when the name clashes with an existing project or when the name is too generic to be added to a Linux distribution.
This name change has no impact on how the library is used though, so it can likely be ignored by most people.