### PR TITLE
Fix crash in GC after clearing a HashMap that held GC-managed objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ test/compile_test
 test/compile_test_32
 test/external_allocator_test
 test/external_allocator_test_32
+test/openhashset
+test/hashmap_gc_test
 .gdb_history
 __test__*__
 *.exe

--- a/src/containers/hashmap.d
+++ b/src/containers/hashmap.d
@@ -97,9 +97,12 @@ struct HashMap(K, V, Allocator = Mallocator, alias hashFunction = generateHash!K
 	{
 		import stdx.allocator : dispose;
 
-		allocator.dispose(buckets);
+		// always remove ranges from GC first before disposing of buckets, to
+		// prevent segfaults when the GC collects at an unfortunate time
 		static if (useGC)
 			GC.removeRange(buckets.ptr);
+		allocator.dispose(buckets);
+
 		buckets = null;
 		_length = 0;
 	}

--- a/src/containers/unrolledlist.d
+++ b/src/containers/unrolledlist.d
@@ -70,12 +70,13 @@ struct UnrolledList(T, Allocator = Mallocator,
 			static if (!(is(T == class) || is(T == interface)))
 				foreach (ref item; previous.items)
 					typeid(T).destroy(&item);
-			allocator.dispose(previous);
+
 			static if (useGC)
 			{
 				import core.memory: GC;
 				GC.removeRange(previous);
 			}
+			allocator.dispose(previous);
 		}
 		_length = 0;
 		_front = null;
@@ -481,12 +482,12 @@ private:
 		if (_back is n)
 			_back = n.prev;
 
-		allocator.dispose(n);
 		static if (useGC)
 		{
 			import core.memory: GC;
 			GC.removeRange(n);
 		}
+		allocator.dispose(n);
 	}
 
 	static bool shouldMerge(const Node* first, const Node* second)

--- a/test/hashmap_gc_test.d
+++ b/test/hashmap_gc_test.d
@@ -1,0 +1,48 @@
+
+import containers : HashMap;
+import std.stdio : writefln;
+import core.memory : GC;
+
+
+/**
+ * Generate a random alphanumeric string.
+ */
+@trusted
+string randomString (uint len)
+{
+    import std.ascii : letters, digits;
+    import std.conv : to;
+    import std.random : randomSample;
+    import std.range : chain;
+
+    auto asciiLetters = to! (dchar[]) (letters);
+    auto asciiDigits = to! (dchar[]) (digits);
+
+    if (len == 0)
+        len = 1;
+
+    auto res = to!string (randomSample (chain (asciiLetters, asciiDigits), len));
+    return res;
+}
+
+void main ()
+{
+    immutable iterationCount = 4;
+    HashMap!(string, string) hmap;
+
+    for (uint n = 1; n <= iterationCount; n++) {
+        foreach (i; 0 .. 1_000_000)
+            hmap[randomString (4)] = randomString (16);
+        GC.collect ();
+        hmap = HashMap!(string, string) (16);
+        GC.collect ();
+
+        foreach (i; 0 .. 1_000_000)
+            hmap[randomString (4)] = randomString (16);
+        GC.collect ();
+        hmap.clear ();
+        GC.collect ();
+
+        writefln ("iteration %s/%s finished", n, iterationCount);
+    }
+}

--- a/test/makefile
+++ b/test/makefile
@@ -8,10 +8,11 @@ FLAGS32:=$(FLAGS) -m32
 
 all: all_32 all_64
 
-all_64: test compile_test external_allocator_test
+all_64: test compile_test external_allocator_test hashmap_gc_test
 	./tests
 	./compile_test
 	./external_allocator_test
+	./hashmap_gc_test
 
 all_32: test_32 compile_test_32 external_allocator_test_32
 	./tests_32
@@ -39,6 +40,13 @@ looptest: looptest.d
 		../src/containers/ttree.d \
 		../src/containers/internal/node.d \
 		-I../src/ \
+
+hashmap_gc_test: hashmap_gc_test.d $(SRC)
+	$(DC) -g -inline -O -release \
+		-I../src/ -I../stdx-allocator/source -debug -wi \
+		$(SRC) \
+		hashmap_gc_test.d \
+		-ofhashmap_gc_test
 
 clean:
 	rm -f tests


### PR DESCRIPTION
Hi!
This PR fixes a really hard to debug issue that was discussed at https://forum.dlang.org/thread/vluakgdjxzucstjbygme@forum.dlang.org?page=1
Credits to pointing out the issue go to [Dmitry Olshansky](https://forum.dlang.org/post/tmxmmpjagddufjngprbe@forum.dlang.org)

I added a test case which I used here to reproduce the bug locally as well as on two other machines. Most of the time, a crash occurs right in the first iteration, but sometimes it takes slightly longer.
In all cases, the patch in this PR fixed the issue.

Cheers,
    Matthias
