### PR TITLE
Upgrade stdx.allocator to 2.77.2

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
         "DLang Community"
     ],
     "dependencies": {
-        "stdx-allocator": "~>2.77.0"
+        "stdx-allocator": "~>2.77.2"
     },
     "configurations": [
         {


### PR DESCRIPTION
This is to ensure Circle CI passes at dlang/phobos#6515

@BBasile @wilzbach 