### PR TITLE
fix #116 - unittest build type is always set

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -10,10 +10,10 @@
     "dependencies": {
         "stdx-allocator": "~>2.77.2"
     },
-    "configurations": [
-        {
-            "name": "unittest",
+    "buildTypes" : {
+        "unittest" : {
+            "buildOptions": ["unittests", "debugMode", "debugInfo"],
             "versions": ["emsi_containers_unittest"]
         }
-    ]
+    }
 }


### PR DESCRIPTION
I'm sure that the idea was to customize the build type and not to add a configuration.