### PR TITLE
Link test_dcontainers with shared runtime via LDC switch '-link-defau…

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,12 @@ dcontainers_dep = declare_dependency(
 #
 # Tests
 #
+if meson.get_compiler('d').get_id() == 'llvm'
+  extra_args = ['-main', '-link-defaultlib-shared']
+else
+  extra_args = ['-main']
+endif
+
 dcontainers_test_exe = executable('test_dcontainers',
     [dcontainers_src,
     'test/compile_test.d',
@@ -72,7 +78,7 @@ dcontainers_test_exe = executable('test_dcontainers',
     include_directories: [src_dir],
     dependencies: [allocator_dep],
     d_unittest: true,
-    link_args: '-main'
+    link_args: extra_args
 )
 test('test_dcontainers', dcontainers_test_exe)
 


### PR DESCRIPTION
…ltlib-shared'.

I hit bug when building dsymbol: 
```
/home/travis/build/dlang-community/dsymbol/build/subprojects/dcontainers/test_dcontainers
--- stderr ---
Aborting from rt/sections_elf_shared.d(489) Only one D shared object allowed for static runtime. Link with shared runtime via LDC switch '-link-defaultlib-shared'.
```
https://travis-ci.org/dlang-community/dsymbol/jobs/423404254

This simple PR link the test with -link-defaultlib-shared.