### PR TITLE
hash without using explicitly typeid

### DIFF
--- a/src/containers/internal/hash.d
+++ b/src/containers/internal/hash.d
@@ -8,16 +8,16 @@ module containers.internal.hash;
 
 static if (hash_t.sizeof == 4)
 {
-	hash_t generateHash(T)(T value) nothrow @trusted
+	hash_t generateHash(T)(const T value)
 	{
-		return typeid(T).getHash(&value);
+		return hashOf(value);
 	}
 }
 else
 {
-	hash_t generateHash(T)(T value) nothrow @trusted if (!is(T == string))
+	hash_t generateHash(T)(T value) if (!is(T == string))
 	{
-		return typeid(T).getHash(&value);
+		return hashOf(value);
 	}
 
 	/**


### PR DESCRIPTION
Inspired by https://issues.dlang.org/show_bug.cgi?id=19197.
Add to this the fact that `typeid` added an indirection.

I can see a 5% perf gain in this insertion benchmark, using dmd

```d
#!dmd -O -release -inline
module runnable;

void main()
{
    import std.datetime.stopwatch;
    import containers.hashset;
    import std.stdio;

    void test()
    {
        StopWatch sw;
        sw.start;
        HashSet!(size_t) hs;
        foreach(i; 0 .. 10_000_000)
            hs.insert (i / 2);
        writeln(sw.peek);
    }

    test();
}
```