### PR TITLE
containers.hashmap: Fix redundant hashFunction call in getOrAdd

### DIFF
--- a/src/containers/hashmap.d
+++ b/src/containers/hashmap.d
@@ -166,8 +166,8 @@ struct HashMap(K, V, Allocator = Mallocator, alias hashFunction = generateHash!K
 	{
 		alias CET = ContainerElementType!(This, V);
 
-		Hash hash = hashFunction(key);
-		auto n = find(key, hash);
+		size_t i;
+		auto n = find(key, i);
 		if (n is null)
 			return cast(CET*) &insert(key, defaultValue).value;
 		else
@@ -634,7 +634,7 @@ version(emsi_containers_unittest) unittest
 
 version(emsi_containers_unittest) unittest
 {
-	HashMap!(int, int) map;
+	HashMap!(int, int, Mallocator, (int i) => i) map;
 	auto p = map.getOrAdd(1, 1);
 	assert(*p == 1);
 	*p = 2;


### PR DESCRIPTION
The result was being thrown away by being overwritten inside `find`. Additionally, when a hash function was specified with a return value other than `size_t`, this resulted in a compilation error.

The bug is a regression (introduced in commit 15eea7fbc89f073838d14d86d47c1247dbe8c3a1).

Fix by letting `find` compute the hash as in other invocations.
