### PR TITLE
fix CI failure due to Python environment and Meson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: d
 sudo: false
-dist: trusty
+dist: xenial
 
 addons:
   apt:
@@ -13,8 +13,8 @@ branches:
   - master
 
 install:
-  - pyenv global system 3.6
-  - pip3 install 'meson==0.47.2'
+  - sudo apt-get install python3-pip python3-setuptools
+  - pip3 install 'meson==0.48.2'
   - mkdir .ntmp
   - curl -L https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip -o .ntmp/ninja-linux.zip
   - unzip .ntmp/ninja-linux.zip -d .ntmp


### PR DESCRIPTION
TravisCI move from a docker based infrastructure to VM based one has broken the script. Fix was suggested on their official forum (that is to use Ubuntu xenial).