### PR TITLE
fix #136 - Error: cannot implicitly convert expression ~this.registry…

### DIFF
--- a/src/containers/unrolledlist.d
+++ b/src/containers/unrolledlist.d
@@ -565,7 +565,7 @@ private:
 			static if (BookkeepingType.sizeof < uint.sizeof)
 				immutable uint notReg = ~(cast(uint) registry);
 			else
-				immutable uint notReg = ~registry;
+				immutable uint notReg = cast(uint) (~registry);
 			version (LDC)
 			{
 				import ldc.intrinsics : llvm_cttz;


### PR DESCRIPTION
… of type const(ulong) to immutable(uint)

building D-Scanner and DCD (or maybe it was another one) is broken because of this, so this is a fix by default, meaning unconvinced.