### PR TITLE
fix: use std.experimental allocator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "stdx-allocator"]
-	path = stdx-allocator
-	url = https://github.com/dlang-community/stdx-allocator

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@ Containers [![CI status](https://travis-ci.org/dlang-community/containers.svg?br
 
 Containers backed by std.experimental.allocator
 
-# Dependencies
-Run `git submodule update --init --recursive` after cloning this repository.
-
 # Documentation
 Documentation is available at http://dlang-community.github.io/containers/index.html
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -8,4 +8,3 @@ buildType "unittest" {
 	versions "emsi_containers_unittest"
 	buildOptions "debugMode" "debugInfo" "unittests"
 }
-dependency "stdx-allocator" version="~>2.77.5"

--- a/meson.build
+++ b/meson.build
@@ -6,9 +6,6 @@ project('dcontainers', 'd',
 
 project_soversion = '0'
 
-pkgc = import('pkgconfig')
-allocator_dep = dependency('stdx-allocator', version: '>= 2.77', fallback: ['stdx-allocator', 'allocator_dep'])
-
 #
 # Sources
 #
@@ -42,13 +39,12 @@ dcontainers_lib = static_library('dcontainers',
         [dcontainers_src],
         include_directories: [src_dir],
         install: true,
-        dependencies: [allocator_dep]
 )
 
+pkgc = import('pkgconfig')
 pkgc.generate(name: 'dcontainers',
               libraries: [dcontainers_lib],
               subdirs: 'd/containers',
-              requires: ['stdx-allocator'],
               version: meson.project_version(),
               description: 'Containers backed by std.experimental.allocator.'
 )
@@ -57,7 +53,6 @@ pkgc.generate(name: 'dcontainers',
 dcontainers_dep = declare_dependency(
     link_with: [dcontainers_lib],
     include_directories: [src_dir],
-    dependencies: [allocator_dep]
 )
 
 #
@@ -70,7 +65,6 @@ dcontainers_test_exe = executable('test_dcontainers',
     'test/compile_test.d',
     'test/external_allocator_test.d'],
     include_directories: [src_dir],
-    dependencies: [allocator_dep],
     d_unittest: true,
     link_args: extra_args
 )

--- a/src/containers/cyclicbuffer.d
+++ b/src/containers/cyclicbuffer.d
@@ -8,7 +8,7 @@
 module containers.cyclicbuffer;
 
 private import core.exception : onRangeError;
-private import stdx.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.mallocator : Mallocator;
 private import std.range.primitives : empty, front, back, popFront, popBack;
 private import containers.internal.node : shouldAddGCRange;
 
@@ -26,7 +26,7 @@ struct CyclicBuffer(T, Allocator = Mallocator, bool supportGC = shouldAddGCRange
 	@disable this(this);
 
 	private import std.conv : emplace;
-	private import stdx.allocator.common : stateSize;
+	private import std.experimental.allocator.common : stateSize;
 	private import std.traits : isImplicitlyConvertible, hasElaborateDestructor;
 
 	static if (stateSize!Allocator != 0)
@@ -449,8 +449,8 @@ private:
 version(emsi_containers_unittest) private
 {
 	import std.algorithm.comparison : equal;
-	import stdx.allocator.gc_allocator : GCAllocator;
-	import stdx.allocator.building_blocks.free_list : FreeList;
+	import std.experimental.allocator.gc_allocator : GCAllocator;
+	import std.experimental.allocator.building_blocks.free_list : FreeList;
 	import std.range : iota, lockstep, StoppingPolicy;
 
 	struct S

--- a/src/containers/dynamicarray.d
+++ b/src/containers/dynamicarray.d
@@ -8,7 +8,7 @@
 module containers.dynamicarray;
 
 private import containers.internal.node : shouldAddGCRange;
-private import stdx.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.mallocator : Mallocator;
 
 /**
  * Array that is able to grow itself when items are appended to it. Uses
@@ -24,7 +24,7 @@ struct DynamicArray(T, Allocator = Mallocator, bool supportGC = shouldAddGCRange
 {
 	this(this) @disable;
 
-	private import stdx.allocator.common : stateSize;
+	private import std.experimental.allocator.common : stateSize;
 
 	static if (is(typeof((T[] a, const T[] b) => a[0 .. b.length] = b[0 .. $])))
 	{
@@ -61,7 +61,7 @@ struct DynamicArray(T, Allocator = Mallocator, bool supportGC = shouldAddGCRange
 
 	~this()
 	{
-		import stdx.allocator.mallocator : Mallocator;
+		import std.experimental.allocator.mallocator : Mallocator;
 		import containers.internal.node : shouldAddGCRange;
 
 		if (arr is null)
@@ -110,7 +110,7 @@ struct DynamicArray(T, Allocator = Mallocator, bool supportGC = shouldAddGCRange
 	 */
 	void insertBack(T value)
 	{
-		import stdx.allocator.mallocator : Mallocator;
+		import std.experimental.allocator.mallocator : Mallocator;
 		import containers.internal.node : shouldAddGCRange;
 
 		if (arr.length == 0)

--- a/src/containers/hashmap.d
+++ b/src/containers/hashmap.d
@@ -9,7 +9,7 @@ module containers.hashmap;
 
 private import containers.internal.hash;
 private import containers.internal.node : shouldAddGCRange;
-private import stdx.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.mallocator : Mallocator;
 private import std.traits : isBasicType, Unqual;
 
 /**
@@ -28,7 +28,7 @@ struct HashMap(K, V, Allocator = Mallocator, alias hashFunction = generateHash!K
 {
 	this(this) @disable;
 
-	private import stdx.allocator.common : stateSize;
+	private import std.experimental.allocator.common : stateSize;
 
 	static if (stateSize!Allocator != 0)
 	{
@@ -96,7 +96,7 @@ struct HashMap(K, V, Allocator = Mallocator, alias hashFunction = generateHash!K
 	 */
 	void clear()
 	{
-		import stdx.allocator : dispose;
+		import std.experimental.allocator : dispose;
 
 		// always remove ranges from GC first before disposing of buckets, to
 		// prevent segfaults when the GC collects at an unfortunate time
@@ -354,7 +354,7 @@ struct HashMap(K, V, Allocator = Mallocator, alias hashFunction = generateHash!K
 
 private:
 
-	import stdx.allocator : make, makeArray;
+	import std.experimental.allocator : make, makeArray;
 	import containers.unrolledlist : UnrolledList;
 	import containers.internal.storage_type : ContainerStorageType;
 	import containers.internal.element_type : ContainerElementType;

--- a/src/containers/hashset.d
+++ b/src/containers/hashset.d
@@ -9,7 +9,7 @@ module containers.hashset;
 
 private import containers.internal.hash : generateHash, hashToIndex;
 private import containers.internal.node : shouldAddGCRange;
-private import stdx.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.mallocator : Mallocator;
 private import std.traits : isBasicType;
 
 /**
@@ -27,7 +27,7 @@ struct HashSet(T, Allocator = Mallocator, alias hashFunction = generateHash!T,
 {
 	this(this) @disable;
 
-	private import stdx.allocator.common : stateSize;
+	private import std.experimental.allocator.common : stateSize;
 
 	static if (stateSize!Allocator != 0)
 	{
@@ -82,7 +82,7 @@ struct HashSet(T, Allocator = Mallocator, alias hashFunction = generateHash!T,
 
 	~this()
 	{
-		import stdx.allocator : dispose;
+		import std.experimental.allocator : dispose;
 		import core.memory : GC;
 		static if (useGC)
 			GC.removeRange(buckets.ptr);
@@ -218,7 +218,7 @@ private:
 	void initialize(size_t bucketCount)
 	{
 		import core.memory : GC;
-		import stdx.allocator : makeArray;
+		import std.experimental.allocator : makeArray;
 
 		makeBuckets(bucketCount);
 		static if (useGC)
@@ -289,7 +289,7 @@ private:
 
 	void makeBuckets(size_t bucketCount)
 	{
-		import stdx.allocator : makeArray;
+		import std.experimental.allocator : makeArray;
 
 		static if (stateSize!Allocator == 0)
 			buckets = allocator.makeArray!Bucket(bucketCount);
@@ -311,7 +311,7 @@ private:
 
 	void rehash() @trusted
 	{
-		import stdx.allocator : makeArray, dispose;
+		import std.experimental.allocator : makeArray, dispose;
 		import core.memory : GC;
 
 		immutable size_t newLength = buckets.length << 1;
@@ -363,7 +363,7 @@ private:
 		~this()
 		{
 			import core.memory : GC;
-			import stdx.allocator : dispose;
+			import std.experimental.allocator : dispose;
 
 			BucketNode* current = root;
 			BucketNode* previous;
@@ -462,7 +462,7 @@ private:
 		bool insert(ItemNode n)
 		{
 			import core.memory : GC;
-			import stdx.allocator : make;
+			import std.experimental.allocator : make;
 
 			BucketNode* hasSpace = null;
 			for (BucketNode* current = root; current !is null; current = current.next)
@@ -489,7 +489,7 @@ private:
 		bool remove(ItemNode n)
 		{
 			import core.memory : GC;
-			import stdx.allocator : dispose;
+			import std.experimental.allocator : dispose;
 
 			BucketNode* current = root;
 			BucketNode* previous;
@@ -747,7 +747,7 @@ version(emsi_containers_unittest) unittest
 
 version(emsi_containers_unittest) unittest
 {
-	import stdx.allocator.showcase;
+	import std.experimental.allocator.showcase;
 	auto allocator = mmapRegionList(1024);
 	auto set = HashSet!(ulong, typeof(&allocator))(0x1000, &allocator);
 	set.insert(124);

--- a/src/containers/immutablehashset.d
+++ b/src/containers/immutablehashset.d
@@ -153,7 +153,7 @@ struct ImmutableHashSet(T, alias hashFunction)
 
 private:
 
-	import stdx.allocator.mallocator : Mallocator;
+	import std.experimental.allocator.mallocator : Mallocator;
 	import std.traits : isBasicType, hasMember;
 	import containers.internal.node : shouldAddGCRange;
 	import core.memory : GC;

--- a/src/containers/openhashset.d
+++ b/src/containers/openhashset.d
@@ -8,8 +8,8 @@ module containers.openhashset;
 
 private import containers.internal.hash;
 private import containers.internal.node : shouldAddGCRange;
-private import stdx.allocator.common : stateSize;
-private import stdx.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.common : stateSize;
+private import std.experimental.allocator.mallocator : Mallocator;
 
 /**
  * Simple open-addressed hash set that uses linear probing to resolve sollisions.

--- a/src/containers/simdset.d
+++ b/src/containers/simdset.d
@@ -6,7 +6,7 @@
  */
 module containers.simdset;
 
-private import stdx.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.mallocator : Mallocator;
 
 /**
  * Set implementation that is well suited for small sets and simple items.
@@ -26,7 +26,7 @@ version (D_InlineAsm_X86_64) struct SimdSet(T, Allocator = Mallocator)
 {
 	this(this) @disable;
 
-	private import stdx.allocator.common : stateSize;
+	private import std.experimental.allocator.common : stateSize;
 
 	static if (stateSize!Allocator != 0)
 	{

--- a/src/containers/slist.d
+++ b/src/containers/slist.d
@@ -8,7 +8,7 @@
 module containers.slist;
 
 private import containers.internal.node : shouldAddGCRange;
-private import stdx.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.mallocator : Mallocator;
 
 /**
  * Single-linked allocator-backed list.
@@ -23,7 +23,7 @@ struct SList(T, Allocator = Mallocator, bool supportGC = shouldAddGCRange!T)
 	/// Disable copying.
 	this(this) @disable;
 
-	private import stdx.allocator.common : stateSize;
+	private import std.experimental.allocator.common : stateSize;
 
 	static if (stateSize!Allocator != 0)
 	{
@@ -261,7 +261,7 @@ struct SList(T, Allocator = Mallocator, bool supportGC = shouldAddGCRange!T)
 
 private:
 
-	import stdx.allocator : make, dispose;
+	import std.experimental.allocator : make, dispose;
 	import containers.internal.node : shouldAddGCRange;
 	import containers.internal.element_type : ContainerElementType;
 	import containers.internal.mixins : AllocatorState;

--- a/src/containers/treemap.d
+++ b/src/containers/treemap.d
@@ -8,7 +8,7 @@
 module containers.treemap;
 
 private import containers.internal.node : shouldAddGCRange;
-private import stdx.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.mallocator : Mallocator;
 
 /**
  * A key→value mapping where the keys are guaranteed to be sorted.
@@ -25,7 +25,7 @@ struct TreeMap(K, V, Allocator = Mallocator, alias less = "a < b",
 {
 	this(this) @disable;
 
-	private import stdx.allocator.common : stateSize;
+	private import std.experimental.allocator.common : stateSize;
 
 	auto allocator()
 	{
@@ -285,10 +285,10 @@ version(emsi_containers_unittest) unittest
 {
 	import std.range.primitives : walkLength;
 	import std.stdio : stdout;
-	import stdx.allocator.building_blocks.allocator_list : AllocatorList;
-	import stdx.allocator.building_blocks.free_list : FreeList;
-	import stdx.allocator.building_blocks.region : Region;
-	import stdx.allocator.building_blocks.stats_collector : StatsCollector;
+	import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
+	import std.experimental.allocator.building_blocks.free_list : FreeList;
+	import std.experimental.allocator.building_blocks.region : Region;
+	import std.experimental.allocator.building_blocks.stats_collector : StatsCollector;
 
 	StatsCollector!(FreeList!(AllocatorList!(a => Region!(Mallocator)(1024 * 1024)),
 		64)) allocator;

--- a/src/containers/ttree.d
+++ b/src/containers/ttree.d
@@ -9,7 +9,7 @@ module containers.ttree;
 
 private import containers.internal.node : shouldAddGCRange;
 private import containers.internal.mixins : AllocatorState;
-private import stdx.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.mallocator : Mallocator;
 
 /**
  * Implements a binary search tree with multiple items per tree node.
@@ -481,7 +481,7 @@ private:
 	import std.functional: binaryFun;
 	import std.range : ElementType, isInputRange;
 	import std.traits: isPointer, PointerTarget;
-	import stdx.allocator.common : stateSize;
+	import std.experimental.allocator.common : stateSize;
 
 	alias N = FatNodeInfo!(T.sizeof, 3, cacheLineSize, ulong.sizeof);
 	alias Value = ContainerStorageType!T;
@@ -533,7 +533,7 @@ private:
 	do
 	{
 		import core.memory : GC;
-		import stdx.allocator : make;
+		import std.experimental.allocator : make;
 
 		static if (stateSize!Allocator == 0)
 			Node* n = make!Node(Allocator.instance);
@@ -554,7 +554,7 @@ private:
 	}
 	do
 	{
-		import stdx.allocator : dispose;
+		import std.experimental.allocator : dispose;
 		import core.memory : GC;
 
 		if (n.left !is null)
@@ -1299,10 +1299,10 @@ version(emsi_containers_unittest) unittest
 	}
 
 	{
-		import stdx.allocator.building_blocks.free_list : FreeList;
-		import stdx.allocator.building_blocks.allocator_list : AllocatorList;
-		import stdx.allocator.building_blocks.region : Region;
-		import stdx.allocator.building_blocks.stats_collector : StatsCollector;
+		import std.experimental.allocator.building_blocks.free_list : FreeList;
+		import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
+		import std.experimental.allocator.building_blocks.region : Region;
+		import std.experimental.allocator.building_blocks.stats_collector : StatsCollector;
 		import std.stdio : stdout;
 
 		StatsCollector!(FreeList!(AllocatorList!(a => Region!(Mallocator)(1024 * 1024)),

--- a/src/containers/unrolledlist.d
+++ b/src/containers/unrolledlist.d
@@ -8,7 +8,7 @@
 module containers.unrolledlist;
 
 private import containers.internal.node : shouldAddGCRange;
-private import stdx.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.mallocator : Mallocator;
 
 version (X86_64)
 	version (LDC)
@@ -33,7 +33,7 @@ struct UnrolledList(T, Allocator = Mallocator,
 {
 	this(this) @disable;
 
-	private import stdx.allocator.common : stateSize;
+	private import std.experimental.allocator.common : stateSize;
 
 	static if (stateSize!Allocator != 0)
 	{
@@ -466,7 +466,7 @@ struct UnrolledList(T, Allocator = Mallocator,
 
 private:
 
-	import stdx.allocator: make, dispose;
+	import std.experimental.allocator: make, dispose;
 	import containers.internal.node : FatNodeInfo, shouldAddGCRange,
 		fullBits, shouldNullSlot;
 	import containers.internal.storage_type : ContainerStorageType;

--- a/subprojects/stdx-allocator.wrap
+++ b/subprojects/stdx-allocator.wrap
@@ -1,4 +1,0 @@
-[wrap-git]
-directory = stdx-allocator
-url       = https://github.com/dlang-community/stdx-allocator.git
-revision  = v2.77.5

--- a/test/external_allocator_test.d
+++ b/test/external_allocator_test.d
@@ -14,11 +14,11 @@ import containers.unrolledlist;
 import std.meta : AliasSeq;
 import std.range.primitives : walkLength;
 import std.stdio : stdout;
-import stdx.allocator.building_blocks.allocator_list : AllocatorList;
-import stdx.allocator.building_blocks.free_list : FreeList;
-import stdx.allocator.building_blocks.region : Region;
-import stdx.allocator.building_blocks.stats_collector : StatsCollector;
-import stdx.allocator.mallocator : Mallocator;
+import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
+import std.experimental.allocator.building_blocks.free_list : FreeList;
+import std.experimental.allocator.building_blocks.region : Region;
+import std.experimental.allocator.building_blocks.stats_collector : StatsCollector;
+import std.experimental.allocator.mallocator : Mallocator;
 
 // Chosen for a very important and completely undocumented reason
 private enum VERY_SPECIFIC_NUMBER = 371;

--- a/test/makefile
+++ b/test/makefile
@@ -1,15 +1,14 @@
 .PHONY: test graphs clean
 
 DC?=dmd
-SRC:=$(shell find ../src/ -name "*.d") \
-	$(shell find ../stdx-allocator/source -name "*.d")
+SRC:=$(shell find ../src/ -name "*.d")
 
 ifeq ($(DC), ldc2)
-  FLAGS:=-unittest -main -g -cov -I../src/ -I../stdx-allocator/source -d-debug -wi
+  FLAGS:=-unittest -main -g -cov -I../src/ -d-debug -wi
   hashmap_gc_test_FLAGS:=-g -O3 -d-debug -wi
   looptest_FLAGS:=-O3
 else
-  FLAGS:=-unittest -main -g -cov -I../src/ -I../stdx-allocator/source -debug -wi
+  FLAGS:=-unittest -main -g -cov -I../src/ -debug -wi
   hashmap_gc_test_FLAGS:=-g -inline -O -release -debug -wi
   looptest_FLAGS:=-inline -O -release
 endif


### PR DESCRIPTION
This removes the dependency on `stdx.allocator` by using the built-in `std.experimental.allocator`.

Closes #166.

![image](https://user-images.githubusercontent.com/16418197/130504840-3cb5f3e6-5eda-4103-9367-b76ac62419c1.png)
