### PR TITLE
Fix writing to dangling pointers to stack

### DIFF
--- a/src/containers/cyclicbuffer.d
+++ b/src/containers/cyclicbuffer.d
@@ -549,27 +549,27 @@ version(emsi_containers_unittest) unittest
 
 version(emsi_containers_unittest) unittest
 {
-	int a = 0;
+	int* a = new int;
 	{
 		CyclicBuffer!S b;
 		{
-			S s = { &a };
+			S s = { a };
 			foreach (i; 0 .. 5)
 				b.insertBack(s);
-			assert(a == 5);
+			assert(*a == 5);
 			foreach (i; 0 .. 5)
-				b.insertBack(S(&a));
-			assert(a == 10);
+				b.insertBack(S(a));
+			assert(*a == 10);
 			foreach (i; 0 .. 5)
 			{
 				b.removeBack();
 				b.removeFront();
 			}
-			assert(a == 20);
+			assert(*a == 20);
 		}
-		assert(a == 21);
+		assert(*a == 21);
 	}
-	assert(a == 21);
+	assert(*a == 21);
 }
 
 version(emsi_containers_unittest) unittest
@@ -678,26 +678,26 @@ version(emsi_containers_unittest) unittest
 
 version(emsi_containers_unittest) unittest
 {
-	int a = 0;
+	int* a = new int;
 	{
 		CyclicBuffer!S b;
 		foreach (i; 0 .. 5)
-			b.insertBack(S(&a));
-		assert(a == 5);
+			b.insertBack(S(a));
+		assert(*a == 5);
 	}
-	assert(a == 10);
-	a = 0;
+	assert(*a == 10);
+	*a = 0;
 	{
 		CyclicBuffer!S b;
 		foreach (i; 0 .. 4)
-			b.insertBack(S(&a));
-		assert(a == 4);
+			b.insertBack(S(a));
+		assert(*a == 4);
 		b.removeFront();
-		assert(a == 5);
-		b.insertBack(S(&a));
-		assert(a == 6);
+		assert(*a == 5);
+		b.insertBack(S(a));
+		assert(*a == 6);
 	}
-	assert(a == 10);
+	assert(*a == 10);
 }
 
 version(emsi_containers_unittest) unittest

--- a/src/containers/dynamicarray.d
+++ b/src/containers/dynamicarray.d
@@ -470,12 +470,12 @@ version(emsi_containers_unittest)
 
 version(emsi_containers_unittest) unittest
 {
-	int a = 0;
+	int* a = new int;
 	{
 		DynamicArray!(Cls) arr;
-		arr.insert(new Cls( & a));
+		arr.insert(new Cls(a));
 	}
-	assert(a == 0); // Destructor not called.
+	assert(*a == 0); // Destructor not called.
 }
 
 version(emsi_containers_unittest) unittest
@@ -522,12 +522,12 @@ version(emsi_containers_unittest) unittest
 
 version(emsi_containers_unittest) unittest
 {
-	int a = 0;
+	int* a = new int;
 	DynamicArray!(Cls, Mallocator, true) arr;
-	arr.insert(new Cls(&a));
+	arr.insert(new Cls(a));
 
 	arr.remove(0);
-	assert(a == 0); // Destructor not called.
+	assert(*a == 0); // Destructor not called.
 }
 
 version(emsi_containers_unittest) unittest
@@ -593,12 +593,12 @@ version(emsi_containers_unittest) unittest
 				++(*a);
 		}
 	}
-	int a = 0;
+	int* a = new int;
 	DynamicArray!S arr;
 	// This next line may segfault if destructors are called
 	// on structs in invalid states.
-	arr.insert(S(&a));
-	assert(a == 1);
+	arr.insert(S(a));
+	assert(*a == 1);
 }
 
 version(emsi_containers_unittest) @nogc unittest


### PR DESCRIPTION
```
Unittest helper types S, C, Cls hold a pointer to a counter which
tracks the number of destructions. However, in some circumstances,
these destructions may be non-deterministic, i.e. occur as a result of
a garbage collection cycle. Should this occur after the unittest has
already exited, then the pointer held by these types will be invalid.

This causes a cyclicbuffer unittest to segfault when compiled with
LDC.

Fix this by always allocating the counter in the managed heap, so that
its lifetime is properly tracked by the garbage collector, along with
the test variables.
```