### PR TITLE
[CI] use MacOS 11 instead of 10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - windows-2019
-          - macos-10.15
+          - macos-11
         d:
           - "ldc-1.27.1"
           - "dmd-2.097.2"


### PR DESCRIPTION
10 is no longer supported by github runners